### PR TITLE
Meetup logos layout

### DIFF
--- a/meetups.js
+++ b/meetups.js
@@ -33,7 +33,7 @@ export const meetups = [
 	{
 		name: "Fusion",
 		logo: meetupFusion,
-		link: "https://www.meetup.com/fusion-technology-meetup-birmingham/",
+		link: "https://meetup.thefusionhub.co.uk/",
 	},
 	{
 		name: "Golang Birmingham",

--- a/src/pages/meetups.jsx
+++ b/src/pages/meetups.jsx
@@ -26,7 +26,7 @@ export default function Meetups() {
 						<li key={meetup.name} className="relative">
 							<div className="group aspect-w-10 aspect-h-7 block w-full overflow-hidden rounded-lg bg-gray-100 focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 focus-within:ring-offset-gray-100">
 								<Link href={meetup.link}>
-									<Image src={meetup.logo} alt={meetup.name}/>
+									<Image src={meetup.logo} alt={meetup.name} className="w-full h-full object-contain object-center p-2"/>
 									<button type="button" className="absolute inset-0 focus:outline-none">
 										<span className="sr-only">View details for {meetup.Name}</span>
 									</button>


### PR DESCRIPTION
fits the meetup logos in the containers like so:

![image](https://user-images.githubusercontent.com/14852491/214917801-c3076ca5-9a12-48b0-8e3c-9e5b0fb4ffca.png)

also updated the Fusion url